### PR TITLE
Node 0.4 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,5 +10,5 @@
   { "node-supervisor" : "lib/cli-wrapper.js"
   , "supervisor" : "lib/cli-wrapper.js"
   }
-, "engines" : { "node" : "~0.2.3 || ~0.3" }
+, "engines" : { "node" : "~0.2.3 || ~0.4.2" }
 }


### PR DESCRIPTION
Just a quick update to package.json to allow use with node 0.4.2.  Working fine for me on OS X 10.6
