### PR TITLE
fixed installing on minor versions of node.js, e.g. 0.4.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,5 +10,5 @@
   { "node-supervisor" : "lib/cli-wrapper.js"
   , "supervisor" : "lib/cli-wrapper.js"
   }
-, "engines" : { "node" : "~0.2.3 || 0.3 || 0.4 || 0.5" }
+, "engines" : { "node" : ">=0.2.3 <=0.5" }
 }


### PR DESCRIPTION
made the version constraint a bit more relaxed, covers a whole range now
