### PR TITLE
Stricter matching of file extensions

### DIFF
--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -38,7 +38,7 @@ function run (args) {
     if (programExt && extensions.indexOf(programExt) == -1)
       extensions += "|" + programExt;
   }
-  fileExtensionPattern = new RegExp(".*\.(" + extensions + ")");
+  fileExtensionPattern = new RegExp("^.*\.(" + extensions + ")$");
   
   if (!executor) {
     executor = (programExt === "coffee") ? "coffee" : "node";


### PR DESCRIPTION
The file extension regexp needs to be anchored, otherwise it will successfully match filenames like `.foo.js.swp`.
