### PR TITLE
--exclude <pattern>

### DIFF
--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -8,6 +8,7 @@ exports.run = run;
 
 function run (args) {
   var arg, next, watch, program, extensions, executor;
+  var excludes = [".swp$"];
   while (arg = args.shift()) {
     if (arg === "--help" || arg === "-h" || arg === "-?") {
       return help();
@@ -17,6 +18,8 @@ function run (args) {
       extensions = args.shift();
     } else if (arg === "--exec" || arg === "-x") {
       executor = args.shift();
+    } else if (arg === "--exclude" || arg === "-ex") {
+      excludes.unshift(args.shift());
     } else if (arg.indexOf("-") && !args.length) {
       // Assume last arg is the program
       program = arg;
@@ -43,13 +46,16 @@ function run (args) {
   if (!executor) {
     executor = (programExt === "coffee") ? "coffee" : "node";
   }
-  
+
   sys.puts("")
   sys.debug("Running node-supervisor with");
   sys.debug("  program '" + program + "'");
   sys.debug("  --watch '" + watch + "'");
   sys.debug("  --extensions '" + extensions + "'");
   sys.debug("  --exec '" + executor + "'");
+  for(var exclude in excludes) {
+	  sys.debug("  --exclude '" + excludes[exclude] + "'");
+  }
   sys.puts("")
   
   // if we have a program, then run it, and restart when it crashes.
@@ -62,7 +68,7 @@ function run (args) {
       watchItem = process.cwd() + '/' + watchItem;
     }
     sys.debug("Watching directory '" + watchItem + "' for changes.");
-    findAllWatchFiles(watchItem, watchGivenFile);
+    findAllWatchFiles(watchItem, watchGivenFile, excludes);
   });
 };
 
@@ -91,6 +97,11 @@ function help () {
     ("    Specific file extensions to watch in addition to defaults.")
     ("    Used when --watch option includes folders")
     ("    Default is 'node|js'")
+    ("")
+    ("  -ex|--exclude <pattern>")
+    ("    A JavaScript regex pattern that will exclude files that it matches.")
+    ("    Use multiple arguments for more than one pattern")
+    ("    Default is to exclude vim swap files (*.swp)")
     ("")
     ("  -x|--exec <executable>")
     ("    The executable that runs the specified program.")
@@ -142,8 +153,24 @@ function watchGivenFile (watch) {
   fs.watchFile(watch, crash);
 }
 
-var findAllWatchFiles = function(path, callback) {
-  fs.stat(path, function(err, stats){
+function isExcluded(path, patterns) {
+  if(!patterns) {
+    return false;
+  }
+  var exclude = false;
+  for(var patternIndex in patterns) {
+    var pattern = patterns[patternIndex];
+    if(path.match(pattern)) {
+      sys.puts('Ignoring ' + path + ' (matched ' + pattern + ')');
+      exclude = true;
+	  break;
+    }
+  }
+  return exclude;
+}
+
+var findAllWatchFiles = function(path, callback, excludes) {
+  fs.stat(path, function(err, stats) {
     if (err) {
       sys.error('Error retrieving stats for file: ' + path);
     } else {
@@ -154,12 +181,12 @@ var findAllWatchFiles = function(path, callback) {
           }
           else {
             fileNames.forEach(function (fileName) {
-              findAllWatchFiles(path + '/' + fileName, callback);
+              findAllWatchFiles(path + '/' + fileName, callback, excludes);
             });
           }
         });
       } else {
-        if (path.match(fileExtensionPattern)) {
+        if (path.match(fileExtensionPattern) && !isExcluded(path, excludes)) {
           callback(path);
         }
       }


### PR DESCRIPTION
Hi nice tool!

However I had a problem straight away. Supervisor will pick up VIM swap files and constantly restart my node server!

The solution I came up with was to automatically exclude *.swp files and to provide an interface to add any custom rules using -ex/--exclude.

The only weakness I can think of with this is that it uses javascript regular expressions. They don't flow out of the command-line writer's fingers quite as easily as globs, but I can't currently think of a way to handle globs without including external libraries or making a very simple script complex.

Anyway, feedback is welcome.

Cheers,
Jon
