### PR TITLE
Group together multiple changes all within a certain window

### DIFF
--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -130,7 +130,7 @@ function crash (oldStat, newStat) {
     sys.debug("crashing child");
     process.kill(child.pid);
     crash_queued = false;
-  }, 500);
+  }, 50);
 }
 
 function watchGivenFile (watch) {


### PR DESCRIPTION
When I batch compile a lot of coffeescript files I get a crash for each js file that had been written.  The I get your error message "Error: Crashing too much, shutting down".

May I suggest a delay option that when it detects a source change it waits for a specified time to see if any others are going to change?  If it sees another change then it restarts the delay timeout.
