### PR TITLE
Fix for Windows

### DIFF
--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -134,13 +134,10 @@ function startProgram (prog, exec, args) {
 }
 
 var timer = null, mtime = null; crash_queued = false;
-function crash (oldStat, newStat) {
+function crash () {
 
-  // we only care about modification time, not access time.
-  if (
-    newStat.mtime.getTime() === oldStat.mtime.getTime()
-    || crash_queued
-  ) return;
+  if (crash_queued)
+    return;
 
   crash_queued = true;
   var child = exports.child;
@@ -151,8 +148,23 @@ function crash (oldStat, newStat) {
   }, 50);
 }
 
+function crashWin (event) {
+  if( event === 'change' )
+    crash();
+}
+
+function crashOther (oldStat, newStat) {
+  // we only care about modification time, not access time.
+  if ( newStat.mtime.getTime() !== oldStat.mtime.getTime() )
+    crash();
+}
+
+var isWindows = process.platform === 'win32';
 function watchGivenFile (watch, poll_interval) {
-  fs.watchFile(watch, { persistent: true, interval: poll_interval }, crash);
+  if (isWindows)
+    fs.watch(watch, { persistent: true, interval: poll_interval }, crashWin);
+  else
+    fs.watchFile(watch, { persistent: true, interval: poll_interval }, crashOther);
 }
 
 var findAllWatchFiles = function(path, callback) {


### PR DESCRIPTION
This is a workaround to make supervisor work on Windows until fs.watchFile is supported
