### PR TITLE
Pull-Request to address issue #36, auto-restarting after crashing code

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ clean up all the inter-module references, and without a whole new
       -x|--exec <executable>
         The executable that runs the specified program.
         Default is 'node'
+        
+      -r|--restart-on-error")
+        Will automatically restart the supervised program.
+        as soon as it ends unexpectedly with an exit code other than 0.
+        When not specified supervisor will wait for another change in the
+        source files, after the program crashed.
 
       -h|--help|-?
         Display these usage instructions.

--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -2,6 +2,8 @@ var util = require("util");
 var fs = require("fs");
 var spawn = require("child_process").spawn;
 var fileExtensionPattern;
+var startChildProcess;
+var restartOnError = false;
 
 exports.run = run;
 
@@ -18,6 +20,8 @@ function run (args) {
       extensions = args.shift();
     } else if (arg === "--exec" || arg === "-x") {
       executor = args.shift();
+    } else if (arg === "--restart-on-error" || arg === "-r") {
+      restartOnError = true;
     } else if (arg === "--") {
       // Remaining args are: program [args, ...]
       program = args.shift();
@@ -60,10 +64,15 @@ function run (args) {
   util.debug("  --extensions '" + extensions + "'");
   util.debug("  --exec '" + executor + "'");
   util.puts("");
-
+  
+  // store the call to startProgramm in startChildProcess
+  // in order to call it later
+  startChildProcess = function() { startProgram(program, executor, programArgs); };
+  
   // if we have a program, then run it, and restart when it crashes.
   // if we have a watch folder, then watch the folder for changes and restart the prog
-  startProgram(program, executor, programArgs);
+  startChildProcess();
+  
   var watchItems = watch.split(',');
   watchItems.forEach(function (watchItem) {
     if (!watchItem.match(/^\/.*/)) { // watch is not an absolute path
@@ -111,6 +120,12 @@ function help () {
     ("    The executable that runs the specified program.")
     ("    Default is 'node'")
     ("")
+    ("  -r|--restart-on-error")
+    ("    Will automatically restart the supervised program")
+    ("    as soon as it ends unexpectedly with an exit code other than 0.")
+    ("    When not specified supervisor will wait for another change in the")
+    ("    source files, after the program crashed.")
+    ("")
     ("  -h|--help|-?")
     ("    Display these usage instructions.")
     ("")
@@ -130,7 +145,16 @@ function startProgram (prog, exec, args) {
   var child = exports.child = spawn(exec, spawnme);
   child.stdout.addListener("data", function (chunk) { chunk && util.print(chunk); });
   child.stderr.addListener("data", function (chunk) { chunk && util.debug(chunk); });
-  child.addListener("exit", function () { startProgram(prog, exec, args); });
+  child.addListener("exit", function (code) { 
+    if (!crash_queued && code !== 0) {
+      // error code, do not restart right now, wait for the file-watcher to call the restart
+      util.debug("Program " + prog + " exited with code " + code + "\n");
+      exports.child = null;
+      if (!restartOnError) return;
+    }
+    crash_queued = false;
+    startProgram(prog, exec, args); 
+  });
 }
 
 var timer = null, mtime = null; crash_queued = false;
@@ -145,9 +169,13 @@ function crash (oldStat, newStat) {
   crash_queued = true;
   var child = exports.child;
   setTimeout(function() {
-    util.debug("crashing child");
-    process.kill(child.pid);
-    crash_queued = false;
+    if (child) {
+      util.debug("crashing child");
+      process.kill(child.pid);
+    } else {
+      util.debug("restarting child");
+      startChildProcess();
+    }
   }, 50);
 }
 


### PR DESCRIPTION
Test whether the exit-code of a child-process is present. 
If it is, do not restart immediately, but wait for the next file-change to happen.

see https://github.com/isaacs/node-supervisor/issues/36
