### PR TITLE
Added the bin/supervisor file

### DIFF
--- a/bin/supervisor
+++ b/bin/supervisor
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require('../lib/cli-wrapper.js');


### PR DESCRIPTION
Added a bin/supervisor so the docs match. And running `supervisor` after an npm install works.
