### PR TITLE
fix when a backgrounded supervisor gets SIGTERM, the sub-proc is not stoped

### DIFF
--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -61,6 +61,19 @@ function run (args) {
     executor = (programExt === "coffee") ? "coffee" : "node";
   }
 
+  // handle case where the supervisor is backgrounded and a SIGTERM is sent
+  // to it, kill the child. Otherwise the child proc keeps running.
+  // This does NOT work with SIGKILL.
+  process.on('SIGTERM', function () {
+    util.debug("About to exit.");
+    var child = exports.child;
+    if (child) {
+      util.debug("Crashing child...");
+      process.kill(child.pid);
+    }
+    process.exit();
+  });
+
   util.puts("")
   util.debug("Running node-supervisor with");
   util.debug("  program '" + program.join(" ") + "'");


### PR DESCRIPTION
Hi,

I implemented a fix to handle a case where the supervisor is backgrounded and a SIGTERM is sent to it, it will kill the child. Right now if I kill the supervisor the child proc keeps running. This does NOT work with SIGKILL.
