### PR TITLE
Support '--extensions' on Windows

### DIFF
--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -197,8 +197,8 @@ function crash () {
   }, 50);
 }
 
-function crashWin (event) {
-  if( event === 'change' )
+function crashWin (event, filename) {
+  if( event === 'change' && (!filename || filename.match(fileExtensionPattern) )
     crash();
 }
 
@@ -220,8 +220,6 @@ var findAllWatchFiles = function(path, callback) {
   fs.stat(path, function(err, stats){
     if (err) {
       util.error('Error retrieving stats for file: ' + path);
-    } else if (isWindows) {
-      callback(path);
     } else {
       if (stats.isDirectory()) {
         fs.readdir(path, function(err, fileNames) {


### PR DESCRIPTION
The option "--extensions" is useful when touching .jade-like file types which doesn't need to restart to apply it. But it didn't work on Windows.
