### PR TITLE
Watch every directory not every files for Windows

### DIFF
--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -257,10 +257,9 @@ var findAllWatchFiles = function(dir, callback) {
   fs.stat(dir, function(err, stats){
     if (err) {
       util.error('Error retrieving stats for file: ' + dir);
-    } else if (isWindows) {
-      callback(dir);
     } else {
       if (stats.isDirectory()) {
+        if (isWindows) callback(dir);
         fs.readdir(dir, function(err, fileNames) {
           if(err) {
             util.error('Error reading path: ' + dir);
@@ -272,7 +271,7 @@ var findAllWatchFiles = function(dir, callback) {
           }
         });
       } else {
-        if (dir.match(fileExtensionPattern)) {
+        if (!isWindows && dir.match(fileExtensionPattern)) {
           callback(dir);
         }
       }


### PR DESCRIPTION
This patch was tested on multiple environments for a couple of weeks properly.
Works well for Windows.
Please consider it.
