### PR TITLE
Use fs.watchFile on Windows with node 0.8+

### DIFF
--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -243,9 +243,10 @@ function crashOther (oldStat, newStat) {
     crash();
 }
 
-var isWindows = process.platform === 'win32';
+var nodeVersion = process.versions.node.substring(0, 3);
+var isWindowsWithoutWatchFile = process.platform === 'win32' && nodeVersion === '0.6';
 function watchGivenFile (watch, poll_interval) {
-  if (isWindows)
+  if (isWindowsWithoutWatchFile)
     fs.watch(watch, { persistent: true, interval: poll_interval }, crashWin);
   else
     fs.watchFile(watch, { persistent: true, interval: poll_interval }, crashOther);
@@ -262,19 +263,19 @@ var findAllWatchFiles = function(dir, callback) {
       util.error('Error retrieving stats for file: ' + dir);
     } else {
       if (stats.isDirectory()) {
-        if (isWindows) callback(dir);
+        if (isWindowsWithoutWatchFile) callback(dir);
         fs.readdir(dir, function(err, fileNames) {
           if(err) {
             util.error('Error reading path: ' + dir);
           }
           else {
             fileNames.forEach(function (fileName) {
-              findAllWatchFiles(dir + '/' + fileName, callback);
+              findAllWatchFiles(path.join(dir, fileName), callback);
             });
           }
         });
       } else {
-        if (!isWindows && dir.match(fileExtensionPattern)) {
+        if (!isWindowsWithoutWatchFile && dir.match(fileExtensionPattern)) {
           callback(dir);
         }
       }


### PR DESCRIPTION
On Windows, with `fs.watch`, supervisor crashes the child when a watched file access time changes. 
Using `fs.watchFile` on node 0.8, the modified time can be checked and thus the child process is only restarted when a watched file really changes.
