### PR TITLE
Fix issue #90: `supervisor file.js` might hang

### DIFF
--- a/lib/cli-wrapper.js
+++ b/lib/cli-wrapper.js
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 var path = require("path")
+  , fs = require("fs")
   , args = process.argv.slice(1)
 
 var arg, base;
 do arg = args.shift();
-while ( arg !== __filename
+while ( fs.realpathSync(arg) !== __filename
   && (base = path.basename(arg)) !== "node-supervisor"
   && base !== "supervisor"
   && base !== "supervisor.js"


### PR DESCRIPTION
If the global `node_modules` directory is in a symlinked path
`process.argv[1]` and `__filename` might differ, despite the fact that
they are pointing to the same file.

This commit normalizes `process.argv[1]` to its "realpath" before
checking for its equivalence to `__filename`.

This commit assumes `__filename` has already been normalized to its
realpath by node. If this is not true, `__filename` will need to be
normalized as well.

Note: This has been tested on Windows 7 only.
