### PR TITLE
Coffee doesn't understand debug or debugBrk options

### DIFF
--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -79,6 +79,11 @@ function run (args) {
     program.unshift("--debug-brk");
   }
 
+  if (executor === "coffee" && (debugFlag || debugBrkFlag)) {
+    // coffee does not understand debug or debug-brk, make coffee pass options to node
+    program.unshift("--nodejs")
+  }
+
   try {
     // Pass kill signals through to child
     [ "SIGTERM", "SIGINT", "SIGHUP", "SIGQUIT" ].forEach( function(signal) {


### PR DESCRIPTION
Passing debug or debugBrk directly into coffee doesn't work, you have to wrap it with --nodejs to have coffee pass the option over to node
