### PR TITLE
Add .litcoffee support. Supervisor will automatically understand this extension.

### DIFF
--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -62,14 +62,20 @@ function run (args) {
   if (!extensions) {
     // If no extensions passed try to guess from the program
     extensions = "node|js";
-    if (programExt && extensions.indexOf(programExt) == -1)
-      extensions += "|" + programExt;
+    if (programExt && extensions.indexOf(programExt) == -1) {
+      // Support coffee and litcoffee extensions
+      if(programExt === "coffee" || programExt === "litcoffee") {
+        extensions += "|coffee|litcoffee";
+      } else {
+        extensions += "|" + programExt;
+      }
+    }
   }
   extensions = extensions.replace(/,/g, "|");
   fileExtensionPattern = new RegExp("^.*\.(" + extensions + ")$");
 
   if (!executor) {
-    executor = (programExt === "coffee") ? "coffee" : "node";
+    executor = (programExt === "coffee" || programExt === "litcoffee") ? "coffee" : "node";
   }
 
   if (debugFlag) {


### PR DESCRIPTION
Since CoffeeScript 1.5.0 theres also a .litcoffee extension which is executed with coffee. Support for .litcoffee is now added.
