### PR TITLE
Optionally use fs.lstat to read symlinks

### DIFF
--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -8,6 +8,7 @@ var noRestartOn = null;
 var debug = true;
 var verbose = false;
 var ignoredPaths = {};
+var useLstat = false;
 
 exports.run = run;
 
@@ -34,6 +35,8 @@ function run (args) {
       executor = args.shift();
     } else if (arg === "--no-restart-on" || arg === "-n") {
       noRestartOn = args.shift();
+    } else if (arg === "--lstat") {
+      useLstat = true;
     } else if (arg === "--debug") {
       debugFlag = true;
     } else if (arg === "--debug-brk") {
@@ -182,6 +185,10 @@ function help () {
     ("    The executable that runs the specified program.")
     ("    Default is 'node'")
     ("")
+    ("  --lstat")
+    ("    Reads symlinks themselves instead of the files they link to. (Uses fs.lstat instead of fs.stat)")
+    ("    Default off. (When off, symlinks will cause errors.)")
+    ("")
     ("  --debug")
     ("    Start node with --debug flag.")
     ("")
@@ -286,7 +293,7 @@ var findAllWatchFiles = function(dir, callback) {
   dir = path.resolve(dir);
   if (ignoredPaths[dir])
     return;
-  fs.stat(dir, function(err, stats){
+  (useLstat ? fs.lstat : fs.stat)(dir, function(err, stats){
     if (err) {
       util.error('Error retrieving stats for file: ' + dir);
     } else {


### PR DESCRIPTION
Currently if a watched directory has symlinks, supervisor reports an error on `fs.stat()` of the symlink.
It could `fs.lstat()` the files instead, which should cause it to read the symlink itself (not the linked file). This PR adds an `--lstat` flag which simply changes the command from `stat` to `lstat`. It's probably only half the solution to symlinks -- it should really `fs.readlink()` the symlink (if `file.isSymbolicLink()`), and then watched the read directory -- but I'm not sure how to best do that generically. So this is half a solution to a situation many people might have, interested in feedback on how to flesh it out.

Thanks!
