### PR TITLE
added '--changed-file-arg' param so program knows what caused a restart

### DIFF
--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -224,13 +224,14 @@ function help () {
 };
 
 function startProgram (prog, exec) {
+  var curProg = prog.slice(0);
   if (crashCausedByFile && changedFileArg) {
-    prog.push('--' + changedFileArg + '=' + crashCausedByFile);
+    curProg.push('--' + changedFileArg + '=' + crashCausedByFile);
     crashCausedByFile = null;
   }
-  util.debug("Starting child process with '" + exec + " " + prog.join(" ") + "'");
+  util.debug("Starting child process with '" + exec + " " + curProg.join(" ") + "'");
   crash_queued = false;
-  var child = exports.child = spawn(exec, prog, {stdio: 'inherit'});
+  var child = exports.child = spawn(exec, curProg, {stdio: 'inherit'});
   if (child.stdout) {
     // node < 0.8 doesn't understand the 'inherit' option, so pass through manually
     child.stdout.addListener("data", function (chunk) { chunk && util.print(chunk); });
@@ -238,7 +239,7 @@ function startProgram (prog, exec) {
   }
   child.addListener("exit", function (code) {
     if (!crash_queued) {
-      util.debug("Program " + exec + " " + prog.join(" ") + " exited with code " + code + "\n");
+      util.debug("Program " + exec + " " + curProg.join(" ") + " exited with code " + code + "\n");
       exports.child = null;
       if (noRestartOn == "exit" || noRestartOn == "error" && code !== 0) return;
     }


### PR DESCRIPTION
Use case: Supervisor is watching for .coffee, .styl, and .jade files, and on any changes, lints them and statically compiles them for the client (using [grunt](http://gruntjs.com)) and runs the app. However, that build process takes 10 seconds, and it doesn't need to do the whole thing on every change. If a .styl file changes, for example, it should only re-compile those files, not the .coffee files, etc.

So, I'd like to pass my program (which supervisor restarts) a flag telling it what caused the restart, so it can be smart about what it builds.
In order to accomplish this, I added a `--changed-file-arg` param to supervisor. So for example, if I run supervisor with `-x node --changed-file-arg=restarted-by -- build_app.js`, when supervisor restarts my program because of a change to /app/some-file.js, it will add that parameter, and run `node build_app.js --restart-by=/app/some-file.js`. Then that script can react accordingly.

The way it's implemented uses a variable in the top-level scope of supervisor, because a) the `exit` event doesn't easily take parameters, and b) supervisor is only managing one program at a time anyway.

Thoughts?
