### PR TITLE
Added --force-watch option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ clean up all the inter-module references, and without a whole new
         If "error", an exit code of 0 will still restart.
         If "exit", no restart regardless of exit code.
 
+      --force-watch
+        Use fs.watch instead of fs.watchFile.
+        This may be useful if you see a high cpu load on a windows machine.
+
       -h|--help|-?
         Display these usage instructions.
 

--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -8,6 +8,7 @@ var noRestartOn = null;
 var debug = true;
 var verbose = false;
 var ignoredPaths = {};
+var forceWatchFlag = false;
 
 exports.run = run;
 
@@ -38,6 +39,8 @@ function run (args) {
       debugFlag = true;
     } else if (arg === "--debug-brk") {
       debugBrkFlag = true;
+    } else if (arg === "--force-watch") {
+      forceWatchFlag = true;
     } else if (arg === "--") {
       program = args;
       break;
@@ -194,6 +197,10 @@ function help () {
     ("    If \"error\", an exit code of 0 will still restart.")
     ("    If \"exit\", no restart regardless of exit code.")
     ("")
+    ("  --force-watch")
+    ("    Use fs.watch instead of fs.watchFile.")
+    ("    This may be useful if you see a high cpu load on a windows machine.")
+    ("")
     ("  -h|--help|-?")
     ("    Display these usage instructions.")
     ("")
@@ -274,7 +281,7 @@ function crashOther (oldStat, newStat) {
 var nodeVersion = process.version.split(".");
 var isWindowsWithoutWatchFile = process.platform === 'win32' && parseInt(nodeVersion[1]) <= 6;
 function watchGivenFile (watch, poll_interval) {
-  if (isWindowsWithoutWatchFile)
+  if (isWindowsWithoutWatchFile || forceWatchFlag)
     fs.watch(watch, { persistent: true, interval: poll_interval }, crashWin);
   else
     fs.watchFile(watch, { persistent: true, interval: poll_interval }, crashOther);
@@ -291,7 +298,7 @@ var findAllWatchFiles = function(dir, callback) {
       util.error('Error retrieving stats for file: ' + dir);
     } else {
       if (stats.isDirectory()) {
-        if (isWindowsWithoutWatchFile) callback(dir);
+        if (isWindowsWithoutWatchFile || forceWatchFlag) callback(dir);
         fs.readdir(dir, function(err, fileNames) {
           if(err) {
             util.error('Error reading path: ' + dir);
@@ -303,7 +310,7 @@ var findAllWatchFiles = function(dir, callback) {
           }
         });
       } else {
-        if (!isWindowsWithoutWatchFile && dir.match(fileExtensionPattern)) {
+        if ((!isWindowsWithoutWatchFile || !forceWatchFlag) && dir.match(fileExtensionPattern)) {
           callback(dir);
         }
       }


### PR DESCRIPTION
This forces the use of fs.watch instead of fs.watchFile.

I added this option as I constantly having a CPU load of 100% on 5 files on Windows 7 x64 with an ssd and node 0.10.15.
