### PR TITLE
Windows doesn't kill processes spawned by the script when script gets killed.

### DIFF
--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -9,9 +9,118 @@ var debug = true;
 var verbose = false;
 var ignoredPaths = {};
 var forceWatchFlag = false;
-var log = console.log
+var log = console.log;
 
 exports.run = run;
+
+function determineDescendants(process_id, callback) {
+  if(process.platform === 'win32') {
+    psWin32(process_id, function(output) { parseDescendants(process_id, output, callback); });
+  } else {
+    callback([]);
+  }
+}
+
+function parseDescendants(process_id, psOutput, callback) {
+  psOutput = "" + psOutput; // to string
+  var lines = psOutput.split(/\n/).map(function(a) {
+    return a.replace(/^\s+|\s+$/g, '');
+  });
+  lines = lines.slice(1, -1);
+  lines = lines.map(function(line) {
+    return line.split(/\s+/);
+  });
+  var pstree = {};
+  lines.forEach(function(fields) {
+    var pid = fields[0];
+    var ppid = fields[1];
+    if(!pstree[ppid]) {
+        pstree[ppid] = [ pid ];
+    } else {
+        pstree[ppid].push(pid);
+    }
+  });
+  
+  var parents = [ process_id ];
+  var descendants = [];
+  while(parents.length > 0) {
+    var parent = parents.shift();
+    var children = pstree[parent];
+    if(children) {
+      Array.prototype.push.apply(descendants, children);
+      Array.prototype.push.apply(parents, children);
+    }
+  }
+  callback(descendants);
+}
+
+function psWin32(process_id, outputCallback) {     
+  var output = "";
+  var process = require('child_process')
+      .spawn('powershell.exe', ['-NoProfile', '-ExecutionPolicy', 'bypass', '-Command', '-']);
+  
+  process.on('exit', function() { outputCallback(output); });
+
+  process.stdout.addListener("data", function (chunk) {
+    if(chunk) {
+        output += chunk;
+    }
+  });
+  
+  process.stdin.write(function() {/*
+    
+  # PowerShell
+  $ProcessesById = @{}
+  foreach ($Process in (Get-WMIObject -Class Win32_Process)) {
+    $ProcessesById[$Process.ProcessId] = $Process
+  }
+  
+  $ProcessesWithoutParents = @()
+  $ProcessesByParent = @{}
+  foreach ($Pair in $ProcessesById.GetEnumerator()) {
+    $Process = $Pair.Value
+  
+    if (($Process.ParentProcessId -eq 0) -or !$ProcessesById.ContainsKey($Process.ParentProcessId)) {
+      $ProcessesWithoutParents += $Process
+      continue
+    }
+  
+    if (!$ProcessesByParent.ContainsKey($Process.ParentProcessId)) {
+      $ProcessesByParent[$Process.ParentProcessId] = @()
+    }
+    $Siblings = $ProcessesByParent[$Process.ParentProcessId]
+    $Siblings += $Process
+    $ProcessesByParent[$Process.ParentProcessId] = $Siblings
+  }
+  
+  function Show-ProcessTree([UInt32]$ProcessId, $IndentLevel) {
+    $Process = $ProcessesById[$ProcessId]
+    $Indent = " " * $IndentLevel
+    if ($Process.CommandLine) {
+      $Description = $Process.CommandLine
+    } else {
+      $Description = $Process.Caption
+    }
+  
+    Write-Host ("{0,6} {1,6}{2} {3}" -f $Process.ProcessId, $Process.ParentProcessId, $Indent, $Description)
+    foreach ($Child in ($ProcessesByParent[$ProcessId] | Sort-Object CreationDate)) {
+      Show-ProcessTree $Child.ProcessId ($IndentLevel + 4)
+    }
+  }
+  
+  Write-Host ("{0,6} {1,6} {2}" -f "PID", "PPID", "Command Line")
+  
+  # foreach ($Process in ($ProcessesWithoutParents | Sort-Object CreationDate)) {
+  #   Show-ProcessTree $Process.ProcessId 0
+  # }
+
+  Show-ProcessTree {{id}} 0
+
+  */}.toString().replace(/^.*?\/\*|\*\/.*?$/g, '').replace("{{id}}", process_id)
+  );
+  
+  process.stdin.end();
+}
 
 function run (args) {
   var arg, next, watch, ignore, program, extensions, executor, poll_interval, debugFlag, debugBrkFlag, debugBrkFlagArg, harmony;
@@ -257,7 +366,12 @@ function crash () {
   setTimeout(function() {
     if (child) {
       log("crashing child");
-      process.kill(child.pid);
+
+      determineDescendants(child.pid, function (descendant_pids) {
+        descendant_pids.forEach(function(descendant_pid) { process.kill(descendant_pid); });
+        process.kill(child.pid);
+      });
+      
     } else {
       log("restarting child");
       startChildProcess();


### PR DESCRIPTION
After this change you can use supervisor on Windows to run cofferscript files like that:

supervisor -x coffee.cmd index.coffee
 
The point of the change is to kill child process spawned by the coffee.cmd when there's need to restart the server. Windows (unlike linux?) doesn't seem to kill it automatically when coffee.cmd itself is killed.

Some discussion regarding the issue:
https://github.com/isaacs/node-supervisor/issues/83#issuecomment-40898374
