### PR TITLE
exit when child has exited, not earlier (mh)

### DIFF
--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -9,7 +9,7 @@ var debug = true;
 var verbose = false;
 var ignoredPaths = {};
 var forceWatchFlag = false;
-var log = console.log
+var log = console.log;
 
 exports.run = run;
 
@@ -94,7 +94,7 @@ function run (args) {
   }
   if (executor === "coffee" && (debugFlag || debugBrkFlag)) {
     // coffee does not understand debug or debug-brk, make coffee pass options to node
-    program.unshift("--nodejs")
+    program.unshift("--nodejs");
   }
 
   try {
@@ -103,10 +103,22 @@ function run (args) {
       process.on(signal, function () {
         var child = exports.child;
         if (child) {
-          log("Sending "+signal+" to child...");
+          // Remove all exit handlers that might cause a restart (mh)
+          child.removeAllListeners('exit');
+
+          log("Sending "+signal+" to child ...");
+
+          child.on('exit', function(code) {
+            log("Program " + executor + " " + program.join(" ") + " exited with code " + code);
+            exports.child = null;
+            // Only here, exit supervisor when child process has exited as well
+            process.exit();
+          });
+
           child.kill(signal);
+        } else {
+          process.exit();
         }
-        process.exit();
       });
     });
   } catch(e) {
@@ -114,7 +126,7 @@ function run (args) {
     // https://github.com/joyent/node/issues/1553
   }
 
-  log("")
+  log("");
   log("Running node-supervisor with");
   log("  program '" + program.join(" ") + "'");
   log("  --watch '" + watch + "'");


### PR DESCRIPTION
With this little addition, the supervisor won't exit until the child process has really exited.

I need this feature because my app has a graceful shutdown.

Already tested it on my machine and works well. Also added few missing semicolons.
