### PR TITLE
no restart on exit with code 0 -- normal exit (without errors) and restart only if errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,12 @@ clean up all the inter-module references, and without a whole new
       --harmony
         Start node with --harmony flag.
 
-      -n|--no-restart-on error|exit
+      -n|--no-restart-on error|exit|exit0
         Don't automatically restart the supervised program if it ends.
         Supervisor will wait for a change in the source files.
         If "error", an exit code of 0 will still restart.
         If "exit", no restart regardless of exit code.
+        If "exit0", no restart only if exit code is 0.
 
       --force-watch
         Use fs.watch instead of fs.watchFile.

--- a/README.md
+++ b/README.md
@@ -52,12 +52,12 @@ clean up all the inter-module references, and without a whole new
       --harmony
         Start node with --harmony flag.
 
-      -n|--no-restart-on error|exit|exit0
+      -n|--no-restart-on error|exit|success
         Don't automatically restart the supervised program if it ends.
         Supervisor will wait for a change in the source files.
         If "error", an exit code of 0 will still restart.
         If "exit", no restart regardless of exit code.
-        If "exit0", no restart only if exit code is 0.
+        If "success", no restart only if exit code is 0.
 
       --force-watch
         Use fs.watch instead of fs.watchFile.

--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -205,7 +205,7 @@ function help () {
     ("    Supervisor will wait for a change in the source files.")
     ("    If \"error\", an exit code of 0 will still restart.")
     ("    If \"exit\", no restart regardless of exit code.")
-    ("    If \"exit0\", no restart only if exit code is 0.")
+    ("    If \"success\", no restart only if exit code is 0.")
     ("")
     ("  --force-watch")
     ("    Use fs.watch instead of fs.watchFile.")
@@ -241,7 +241,7 @@ function startProgram (prog, exec) {
     if (!crash_queued) {
       log("Program " + exec + " " + prog.join(" ") + " exited with code " + code + "\n");
       exports.child = null;
-      if (noRestartOn == "exit" || noRestartOn == "error" && code !== 0 || noRestartOn == "exit0" && code === 0) return;
+      if (noRestartOn == "exit" || noRestartOn == "error" && code !== 0 || noRestartOn == "success" && code === 0) return;
     }
     startProgram(prog, exec);
   });

--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -240,7 +240,7 @@ function startProgram (prog, exec) {
     if (!crash_queued) {
       log("Program " + exec + " " + prog.join(" ") + " exited with code " + code + "\n");
       exports.child = null;
-      if (noRestartOn == "exit" || noRestartOn == "error" && code !== 0) return;
+      if (noRestartOn == "exit" || noRestartOn == "error" && code !== 0 || noRestartOn == "exit0" && code === 0) return;
     }
     startProgram(prog, exec);
   });

--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -205,6 +205,7 @@ function help () {
     ("    Supervisor will wait for a change in the source files.")
     ("    If \"error\", an exit code of 0 will still restart.")
     ("    If \"exit\", no restart regardless of exit code.")
+    ("    If \"exit0\", no restart only if exit code is 0.")
     ("")
     ("  --force-watch")
     ("    Use fs.watch instead of fs.watchFile.")


### PR DESCRIPTION
I think restarting is one of the core values of node-supervisor
so maybe there should be more options

this one seems obvious to me -- exit when code "0" and log and restart on error
maybe i haven't read docs enough, it would be cool if this behaviour can be supported with standard options