### PR TITLE
Added missing semicolon in supervisor.js

### DIFF
--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -9,7 +9,7 @@ var debug = true;
 var verbose = false;
 var ignoredPaths = {};
 var forceWatchFlag = false;
-var log = console.log
+var log = console.log;
 
 exports.run = run;
 


### PR DESCRIPTION
I'd propose either adding the semicolon here to the end of line 12, or adding a comment before line 12 which explains the purpose of omitting the semicolon.  If there is a reason, feel free to comment and I'll modify my pull request appropriately.

Credit to https://github.com/isaacs/node-supervisor/pull/129/ for pointing out the missing semicolon.  I just thought this commit would simplify the review process.
