### PR TITLE
Added symlink ignoring capability

### DIFF
--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -8,6 +8,7 @@ var noRestartOn = null;
 var debug = true;
 var verbose = false;
 var ignoredPaths = {};
+var ignoreSymLinks = false;
 var forceWatchFlag = false;
 var log = console.log;
 
@@ -29,6 +30,8 @@ function run (args) {
       watch = args.shift();
     } else if (arg === "--ignore" || arg === "-i") {
       ignore = args.shift();
+    } else if (arg === "--ignore-symlinks") {
+      ignoreSymLinks = true;
     } else if (arg === "--poll-interval" || arg === "-p") {
       poll_interval = parseInt(args.shift());
     } else if (arg === "--extensions" || arg === "-e") {
@@ -178,6 +181,9 @@ function help () {
     ("    A comma-delimited list of folders to ignore for changes.")
     ("    No default")
     ("")
+    ("  --ignore-symlinks")
+    ("    Enable symbolic links ignoring when looking for files to watch.")
+    ("")
     ("  -p|--poll-interval <milliseconds>")
     ("    How often to poll watched files for changes.")
     ("    Defaults to Node default.")
@@ -302,10 +308,15 @@ var findAllWatchFiles = function(dir, callback) {
   dir = path.resolve(dir);
   if (ignoredPaths[dir])
     return;
-  fs.stat(dir, function(err, stats){
+  fs[ignoreSymLinks ? 'lstat' : 'stat'](dir, function(err, stats) {
     if (err) {
       console.error('Error retrieving stats for file: ' + dir);
     } else {
+      if (ignoreSymLinks && stats.isSymbolicLink()) {
+        log("Ignoring symbolic link '" + dir + "'.");
+        return;
+      }
+
       if (stats.isDirectory()) {
         if (isWindowsWithoutWatchFile || forceWatchFlag) callback(dir);
         fs.readdir(dir, function(err, fileNames) {


### PR DESCRIPTION
Recursive symbolic links can cause supervisor to recurse indefinitly.