### PR TITLE
console.log already outputs a newline

### DIFF
--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -152,7 +152,7 @@ function run (args) {
   });
 };
 
-function print (m, n) { console.log(m+(!n?"\n":"")); return print; }
+function print (m) { console.log(m); return print; }
 
 function help () {
   print

--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -9,12 +9,13 @@ var debug = true;
 var verbose = false;
 var ignoredPaths = {};
 var forceWatchFlag = false;
-var log = console.log;
-
+var log = console.log
+var watchedFiles = [];
+var poll_interval = 1000;
 exports.run = run;
 
 function run (args) {
-  var arg, next, watch, ignore, program, extensions, executor, poll_interval, debugFlag, debugBrkFlag, debugBrkFlagArg, harmony;
+  var arg, next, watch, ignore, program, extensions, executor, debugFlag, debugBrkFlag, debugBrkFlagArg, harmony;
   while (arg = args.shift()) {
     if (arg === "--help" || arg === "-h" || arg === "-?") {
       return help();
@@ -57,9 +58,6 @@ function run (args) {
   }
   if (!watch) {
     watch = ".";
-  }
-  if (!poll_interval) {
-    poll_interval = 1000;
   }
 
   var programExt = program.join(" ").match(/.*\.(\S*)/);
@@ -267,18 +265,25 @@ function crash () {
 
 function crashWin (event, filename) {
   var shouldCrash = true;
-  if( event === 'change' ) {
-    if (filename) {
-      filename = path.resolve(filename);
-      Object.keys(ignoredPaths).forEach(function (ignorePath) {
-        if ( filename.indexOf(ignorePath + '\\') === 0 || filename === ignorePath) {
-          shouldCrash = false;
-        }
-      });
-    }
-    if (shouldCrash)
-      crash();
+
+  if (filename) {
+	for(i in watchedFiles){
+		watchedFile = watchedFiles[i];
+		if(watchedFile.indexOf(filename, watchedFile.length - filename.length) !== -1){
+			watchGivenFile(watchedFile, poll_interval);
+		}
+	}
+	  
+    filename = path.resolve(filename);
+    Object.keys(ignoredPaths).forEach(function (ignorePath) {
+      if ( filename.indexOf(ignorePath + '\\') === 0 || filename === ignorePath) {
+        shouldCrash = false;
+      }
+    });
   }
+
+  if (shouldCrash)
+    crash();
 }
 
 function crashOther (oldStat, newStat) {
@@ -290,10 +295,13 @@ function crashOther (oldStat, newStat) {
 var nodeVersion = process.version.split(".");
 var isWindowsWithoutWatchFile = process.platform === 'win32' && parseInt(nodeVersion[1]) <= 6;
 function watchGivenFile (watch, poll_interval) {
-  if (isWindowsWithoutWatchFile || forceWatchFlag)
-    fs.watch(watch, { persistent: true, interval: poll_interval }, crashWin);
-  else
+  watchedFiles.push(watch);
+
+  if (isWindowsWithoutWatchFile || forceWatchFlag){
+	fs.watch(watch, { persistent: true, interval: poll_interval }, crashWin);
+  } else {
     fs.watchFile(watch, { persistent: true, interval: poll_interval }, crashOther);
+  }
   if (verbose)
     log("watching file '" + watch + "'");
 }


### PR DESCRIPTION
print() used to use sys.print in the initial commit, which didn’t append a \n. Now print() uses console.log, which does append a newline to the message. So currently the help message is displaying blank lines, every other line.