### PR TITLE
Add exit handler for parent process

### DIFF
--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -114,6 +114,14 @@ function run (args) {
     // https://github.com/joyent/node/issues/1553
   }
 
+  process.on('exit', function () {
+    var child = exports.child;
+    if (child) {
+      log("Parent process exiting, terminating child...");
+      child.kill();
+    }
+  })
+
   log("")
   log("Running node-supervisor with");
   log("  program '" + program.join(" ") + "'");


### PR DESCRIPTION
Make sure the child process is also killed if the parent exits for any reason. Fixes #144.