### PR TITLE
addin a --save-pid <path> option

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ clean up all the inter-module references, and without a whole new
         The executable that runs the specified program.
         Default is 'node'
 
+      -pid|--save-pid <path>
+        Save supervisor's process id to a file at the given path.
+
       --debug
         Start node with --debug flag.
 

--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -99,6 +99,14 @@ function run (args) {
     // coffee does not understand debug or debug-brk, make coffee pass options to node
     program.unshift("--nodejs")
   }
+  if (pidPath) {
+    var pid = process.pid;
+    fs.writeFileSync(pidPath, pid + '\n');
+  }
+
+  var deletePidFile = function(){
+    fs.unlinkSync(pidPath);
+  }
 
   try {
     // Pass kill signals through to child
@@ -108,6 +116,9 @@ function run (args) {
         if (child) {
           log("Sending "+signal+" to child...");
           child.kill(signal);
+        }
+        if (pidPath){
+          deletePidFile()
         }
         process.exit();
       });
@@ -131,6 +142,7 @@ function run (args) {
   log("  --exec '" + executor + "'");
   log("");
 
+
   // store the call to startProgramm in startChildProcess
   // in order to call it later
   startChildProcess = function() { startProgram(program, executor); };
@@ -148,11 +160,6 @@ function run (args) {
     });
   }
 
-  if (pidPath) {
-    var pid = process.pid;
-    fs.writeFileSync(pidPath, pid + '\n');
-    console.log('pid: ', pid);
-  }
 
   var watchItems = watch.split(',');
   watchItems.forEach(function (watchItem) {

--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -14,7 +14,7 @@ var log = console.log;
 exports.run = run;
 
 function run (args) {
-  var arg, next, watch, ignore, program, extensions, executor, poll_interval, debugFlag, debugBrkFlag, debugBrkFlagArg, harmony;
+  var arg, next, watch, ignore, pidPath, program, extensions, executor, poll_interval, debugFlag, debugBrkFlag, debugBrkFlagArg, harmony;
   while (arg = args.shift()) {
     if (arg === "--help" || arg === "-h" || arg === "-?") {
       return help();
@@ -29,6 +29,9 @@ function run (args) {
       watch = args.shift();
     } else if (arg === "--ignore" || arg === "-i") {
       ignore = args.shift();
+    } else if (arg === "--save-pid" || arg === "-pid") {
+      // arg is the the path where to save supervisor's pid
+      pidPath = args.shift();
     } else if (arg === "--poll-interval" || arg === "-p") {
       poll_interval = parseInt(args.shift());
     } else if (arg === "--extensions" || arg === "-e") {
@@ -121,6 +124,9 @@ function run (args) {
   if (ignore) {
     log("  --ignore '" + ignore + "'");
   }
+  if (pidPath){
+    log("  --save-pid '" + pidPath + "'");
+  }
   log("  --extensions '" + extensions + "'");
   log("  --exec '" + executor + "'");
   log("");
@@ -140,6 +146,12 @@ function run (args) {
       ignoredPaths[ignoreItem] = true;
       log("Ignoring directory '" + ignoreItem + "'.");
     });
+  }
+
+  if (pidPath) {
+    var pid = process.pid;
+    fs.writeFileSync(pidPath, pid + '\n');
+    console.log('pid: ', pid);
   }
 
   var watchItems = watch.split(',');

--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -14,7 +14,7 @@ var log = console.log;
 exports.run = run;
 
 function run (args) {
-  var arg, next, watch, ignore, pidPath, program, extensions, executor, poll_interval, debugFlag, debugBrkFlag, debugBrkFlagArg, harmony;
+  var arg, next, watch, ignore, pidFilePath, program, extensions, executor, poll_interval, debugFlag, debugBrkFlag, debugBrkFlagArg, harmony;
   while (arg = args.shift()) {
     if (arg === "--help" || arg === "-h" || arg === "-?") {
       return help();
@@ -30,8 +30,7 @@ function run (args) {
     } else if (arg === "--ignore" || arg === "-i") {
       ignore = args.shift();
     } else if (arg === "--save-pid" || arg === "-pid") {
-      // arg is the the path where to save supervisor's pid
-      pidPath = args.shift();
+      pidFilePath = args.shift();
     } else if (arg === "--poll-interval" || arg === "-p") {
       poll_interval = parseInt(args.shift());
     } else if (arg === "--extensions" || arg === "-e") {
@@ -99,14 +98,12 @@ function run (args) {
     // coffee does not understand debug or debug-brk, make coffee pass options to node
     program.unshift("--nodejs")
   }
-  if (pidPath) {
+  if (pidFilePath) {
     var pid = process.pid;
-    fs.writeFileSync(pidPath, pid + '\n');
+    fs.writeFileSync(pidFilePath, pid + '\n');
   }
 
-  var deletePidFile = function(){
-    fs.unlinkSync(pidPath);
-  }
+  var deletePidFile = function(){ fs.unlinkSync(pidFilePath); };
 
   try {
     // Pass kill signals through to child
@@ -117,8 +114,8 @@ function run (args) {
           log("Sending "+signal+" to child...");
           child.kill(signal);
         }
-        if (pidPath){
-          deletePidFile()
+        if (pidFilePath){
+          deletePidFile();
         }
         process.exit();
       });
@@ -135,8 +132,8 @@ function run (args) {
   if (ignore) {
     log("  --ignore '" + ignore + "'");
   }
-  if (pidPath){
-    log("  --save-pid '" + pidPath + "'");
+  if (pidFilePath){
+    log("  --save-pid '" + pidFilePath + "'");
   }
   log("  --extensions '" + extensions + "'");
   log("  --exec '" + executor + "'");

--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -139,7 +139,6 @@ function run (args) {
   log("  --exec '" + executor + "'");
   log("");
 
-
   // store the call to startProgramm in startChildProcess
   // in order to call it later
   startChildProcess = function() { startProgram(program, executor); };
@@ -156,7 +155,6 @@ function run (args) {
       log("Ignoring directory '" + ignoreItem + "'.");
     });
   }
-
 
   var watchItems = watch.split(',');
   watchItems.forEach(function (watchItem) {


### PR DESCRIPTION
I wanted to mimic what some processes do, that is saving the process id, usually in /var/run/, in order to be able to `kill $(cat path/to/pid-file)` or other pid-based madnesses.

This became useful when I started experimenting with deamonizing supervisor's process (using [this little tool](https://github.com/AvianFlu/aeternum)). I'm rather young in the world of process management so it might very well be a bad practice (if so, please tell me what would be a better way :) ).

Possible issues:
- as such, I'm not handling `fs` errors such as `EACCES`  or `ENOENT`: as I use sync methods, supervisor just crashs.
- it does the job for what I needed, that is saving in a local folder such as `./run/myprocess.pid` but I didn't tried to make it write in the real `/var/run` as it would imply super-user rights and the mess that comes with it.