### PR TITLE
Improve Windows support when executor missing

### DIFF
--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -234,7 +234,7 @@ function startProgram (prog, exec) {
   // Support for Windows ".cmd" files
   // On Windows 8.1, spawn can't launch apps without the .cmd extention
   // If already retried, let the app crash ... :'(
-  if (process.platform === "win32" && prog.indexOf('.cmd') == -1) {
+  if (process.platform === "win32" && exec.indexOf('.cmd') == -1) {
     child.on('error', function () {
       startProgram(prog, exec + ".cmd");
     });

--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -235,8 +235,9 @@ function startProgram (prog, exec) {
   // On Windows 8.1, spawn can't launch apps without the .cmd extention
   // If already retried, let the app crash ... :'(
   if (process.platform === "win32" && exec.indexOf('.cmd') == -1) {
-    child.on('error', function () {
-      startProgram(prog, exec + ".cmd");
+    child.on('error', function (err) {
+      if (err.code === "ENOENT")
+        return startProgram(prog, exec + ".cmd");
     });
   }
   if (child.stdout) {

--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -231,6 +231,14 @@ function startProgram (prog, exec) {
   log("Starting child process with '" + exec + " " + prog.join(" ") + "'");
   crash_queued = false;
   var child = exports.child = spawn(exec, prog, {stdio: 'inherit'});
+  // Support for Windows ".cmd" files
+  // On Windows 8.1, spawn can't launch apps without the .cmd extention
+  // If already retried, let the app crash ... :'(
+  if (process.platform === "win32" && prog.indexOf('.cmd') == -1) {
+    child.on('error', function () {
+      startProgram(prog, exec + ".cmd");
+    });
+  }
   if (child.stdout) {
     // node < 0.8 doesn't understand the 'inherit' option, so pass through manually
     child.stdout.addListener("data", function (chunk) { chunk && console.log(chunk); });


### PR DESCRIPTION
Automatic retry with ".cmd" extension on Windows plateform.
Useful when executor name is not provider ( and distribute for multiplatform in npm run start command for example )