### PR TITLE
Adding --instant-kill option

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ clean up all the inter-module references, and without a whole new
       --force-watch
         Use fs.watch instead of fs.watchFile.
         This may be useful if you see a high cpu load on a windows machine.
+		
+	  --instant-kill
+	    Instantly kills the server process, instead of gracefully shutting down the server.
+		This can be useful when the node app has events attached to SIGTERM or SIGINT so as to do a graceful shutdown before the process exits.
 
       -h|--help|-?
         Display these usage instructions.

--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -9,6 +9,7 @@ var debug = true;
 var verbose = false;
 var ignoredPaths = {};
 var forceWatchFlag = false;
+var instantKillFlag = false;
 var log = console.log;
 
 exports.run = run;
@@ -46,6 +47,8 @@ function run (args) {
       debugBrkFlagArg = arg;
     } else if (arg === "--force-watch") {
       forceWatchFlag = true;
+    } else if (arg === "--instant-kill") {
+      instantKillFlag = true;
     } else if (arg === "--") {
       program = args;
       break;
@@ -323,7 +326,11 @@ function crash () {
   setTimeout(function() {
     if (child) {
       log("crashing child");
-      process.kill(child.pid);
+      if (instantKillFlag) {
+        process.kill(child.pid, "SIGKILL");
+      } else {
+        process.kill(child.pid);
+      }
     } else {
       log("restarting child");
       startChildProcess();


### PR DESCRIPTION
If the node app has events attached to SIGTERM or SIGINT so as to do a graceful shutdown before the process exits, it can cause supervisor to delay restarting the app, thus kind of killing its utility as a dev tool.

In that circumstance it could be desirable to have supervisor force kill the process rather than allowing the graceful shutdown events to do their thing. This pull request adds an off-by-default flag to allow users to force kill the process rather than wait.