### PR TITLE
More explicit language for killing child process

### DIFF
--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -138,7 +138,7 @@ function run (args) {
       process.on(signal, function () {
         var child = exports.child;
         if (child) {
-          log("Received "+signal+", killing child...");
+          log("Received "+signal+", killing child process...");
           child.kill(signal);
         }
         if (pidFilePath){


### PR DESCRIPTION
I know this is a bit silly, but bear with me. I recently gave a demo of a node app running via supervisor to a relatively nontechnical audience and the phrase "killing child" in the console raised a few eyebrows in the room and required explaining that it is programmer jargon, not a reference to killing children. I'd like to avoid that in the future, thus this rather silly pull request. :smile: 