### PR TITLE
Added restart-verbose option

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ clean up all the inter-module references, and without a whole new
 	  --instant-kill
 	    Instantly kills the server process, instead of gracefully shutting down the server.
 		This can be useful when the node app has events attached to SIGTERM or SIGINT so as to do a graceful shutdown before the process exits.
+		
+     -RV|--restart-verbose
+        Logs the file(s) that caused supervisor to restart
 
       -h|--help|-?
         Display these usage instructions.

--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -6,6 +6,7 @@ var startChildProcess;
 var noRestartOn = null;
 var debug = true;
 var verbose = false;
+var restartVerbose = false;
 var ignoredPaths = {};
 var ignoreSymLinks = false;
 var forceWatchFlag = false;
@@ -27,6 +28,8 @@ function run (args) {
       harmony = true;
     } else if (arg === "--verbose" || arg === "-V") {
       verbose = true;
+    } else if (arg === "--restart-verbose" || arg === "-RV") {
+			restartVerbose = true;
     } else if (arg === "--watch" || arg === "-w") {
       watch = args.shift();
     } else if (arg == "--non-interactive" || arg === "-t") {
@@ -390,6 +393,9 @@ function crashWin (event, filename) {
     if (shouldCrash) {
       if (verbose) {
         log("change detected" + (filename ? ": " + filename : ""));
+      }
+      if (restartVerbose) {
+        log("File(s) that caused the restart: " + filename);
       }
       crash();
     }


### PR DESCRIPTION
Added --restart-verbose / -RV option to log the file that causes the
server to restart. This is useful when the server is restarting at
random times (say a hidden file is being created or modified in the
background). It also could allow you to check to see if you set up the
proper watch and ignore directories. This option is separate from full verbose.