### PR TITLE
Allows for --harmony_default_parameters transfer to node.

### DIFF
--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -25,6 +25,8 @@ function run (args) {
       log = function(){};
     } else if (arg === "--harmony") {
       harmony = true;
+    } else if (arg === "--harmony_default_parameters") {
+      harmony_default_parameters = true;
     } else if (arg === "--verbose" || arg === "-V") {
       verbose = true;
     } else if (arg === "--watch" || arg === "-w") {
@@ -101,6 +103,9 @@ function run (args) {
   }
   if (harmony) {
     program.unshift("--harmony");
+  }
+  if (harmony) {
+    program.unshift("--harmony_default_parameters");
   }
   if (executor === "coffee" && (debugFlag || debugBrkFlag)) {
     // coffee does not understand debug or debug-brk, make coffee pass options to node
@@ -283,6 +288,9 @@ function help () {
     ("")
     ("  --harmony")
     ("    Start node with --harmony flag.")
+    ("")
+    ("  --harmony_default_parameters")
+    ("    Start node with --harmony_default_parameters flag.")
     ("")
     ("  -n|--no-restart-on error|exit")
     ("    Don't automatically restart the supervised program if it ends.")

--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -104,7 +104,7 @@ function run (args) {
   if (harmony) {
     program.unshift("--harmony");
   }
-  if (harmony) {
+  if (harmony_default_parameters) {
     program.unshift("--harmony_default_parameters");
   }
   if (executor === "coffee" && (debugFlag || debugBrkFlag)) {


### PR DESCRIPTION
It is necessary for ES6 default parameters support in node 5.5.0.
Default parameters will be enable by default in node 6.