### PR TITLE
Supporting the `--harmony_destructuring` flag.

### DIFF
--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -16,6 +16,7 @@ var interactive = true;
 var log = console.log;
 var crash_queued = false;
 var harmony_default_parameters = false;
+var harmony_destructuring = false;
 
 exports.run = run;
 
@@ -31,6 +32,8 @@ function run (args) {
             harmony = true;
         } else if (arg === "--harmony_default_parameters") {
             harmony_default_parameters = true;
+        } else if (arg === "--harmony_destructuring") {
+            harmony_destructuring = true;
         } else if (arg === "--verbose" || arg === "-V") {
             verbose = true;
         } else if (arg === "--restart-verbose" || arg === "-RV") {
@@ -114,6 +117,9 @@ function run (args) {
     }
     if (harmony_default_parameters) {
         program.unshift("--harmony_default_parameters");
+    }
+    if (harmony_destructuring) {
+        program.unshift("--harmony_destructuring");
     }
     if (executor === "coffee" && (debugFlag || debugBrkFlag)) {
         // coffee does not understand debug or debug-brk, make coffee pass options to node


### PR DESCRIPTION
This PR adds support for the `--harmony_destructuring` flag when running Supervisor.

I have a project that really benefits from both array destructuring _and_ Supervisor so it was important to make this work. @ruffrey's common on #152 indicates that others might benefit as well if you're so inclined to support the flag.

Please let me know if you'd prefer any changes be made.