### PR TITLE
fixes license string in sampleApp

### DIFF
--- a/test/sampleApp/package.json
+++ b/test/sampleApp/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "Petru Isfan",
-  "license": "Apache2",
+  "license": "Apache-2.0",
   "dependencies": {
     "express": "^4.12.3"
   }


### PR DESCRIPTION
this is useful when using scripts that check for the license string in package.json, for instance when you programmatically want to check for licensing compliance on a project with lots of dependencies