### PR TITLE
Double escape dot

### DIFF
--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -102,7 +102,7 @@ function run (args) {
             }
         }
     }
-    fileExtensionPattern = new RegExp("^.*\.(" + extensions.replace(/,/g, "|") + ")$");
+    fileExtensionPattern = new RegExp("^.*\\.(" + extensions.replace(/,/g, "|") + ")$");
 
     if (!executor) {
         executor = (programExt === "coffee" || programExt === "litcoffee") ? "coffee" : "node";


### PR DESCRIPTION
I noticed that supervisor was refreshing when my `ejs` files changed, even though the specified extensions are `node,js,yaml`.

I think the RegExp match string is missing an escape:
```js
var files = ['alfa.js', 'bravo.ejs'];
files.filter(function(e) { return e.match(/^.*\.js$/); });
// ["alfa.js"]

files.filter(function(e) { return e.match(new RegExp(".*\.js$")); });
// ["alfa.js", "bravo.ejs"]

files.filter(function(e) { return e.match(new RegExp(".*\\.js$")); });
// ["alfa.js"]
```