### PR TITLE
Add support for --flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ clean up all the inter-module references, and without a whole new
       -pid|--save-pid <path>
         Save supervisor's process id to a file at the given path.
 
+      --flags
+        Start with flags, separate several values by comma
+
       --debug[=port]
         Start node with --debug flag.
 

--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -21,7 +21,7 @@ var harmony_destructuring = false;
 exports.run = run;
 
 function run (args) {
-    var arg, next, watch, ignore, pidFilePath, program, extensions, executor, poll_interval, debugFlag, debugBrkFlag, debugBrkFlagArg, harmony, inspect;
+    var arg, next, watch, ignore, pidFilePath, program, extensions, executor, poll_interval, debugFlag, debugBrkFlag, debugBrkFlagArg, harmony, inspect, flags;
     while (arg = args.shift()) {
         if (arg === "--help" || arg === "-h" || arg === "-?") {
             return help();
@@ -30,6 +30,8 @@ function run (args) {
             log = function(){};
         } else if (arg === "--harmony") {
             harmony = true;
+        } else if (arg === "--flags") {
+            flags = args.shift().split(',');
         } else if (arg.indexOf("--inspect") > -1) {
             inspect = arg;
         } else if (arg === "--harmony_default_parameters") {
@@ -116,6 +118,11 @@ function run (args) {
     }
     if (harmony) {
         program.unshift("--harmony");
+    }
+    if (flags) {
+      flags.forEach(function(flag) {
+        program.unshift(flag);
+      })
     }
     if (inspect) {
         program.unshift(inspect);


### PR DESCRIPTION
This enables any flags passthrough to binary.

Example usage: `supervisor --flags '--experimental-modules,--loader=loader.js' index.mjs`

Fixes issues #219 #210 and adds support for any other flags supported by binary.

In a rush or impatient for this to get merged? Just do `npm -g remove node-supervisor && npm -g install mikabytes/node-supervisor` and you'll get this right away.