### PR TITLE
Fix typo

### DIFF
--- a/lib/supervisor.js
+++ b/lib/supervisor.js
@@ -347,7 +347,7 @@ function help () {
     ("")
     ("Options available after start:")
     ("rs - restart process.")
-    ("     Useful for restarting supervisor eaven if no file has changed.")
+    ("     Useful for restarting supervisor even if no file has changed.")
     ("")
     ("Examples:")
     ("  supervisor myapp.js")


### PR DESCRIPTION
I think the word in the sentence could be `even` instead of `eaven` !